### PR TITLE
Fixed problem with guzzle's new version

### DIFF
--- a/src/Adapters/Slack/SlackGateway.php
+++ b/src/Adapters/Slack/SlackGateway.php
@@ -101,7 +101,7 @@ class SlackGateway implements GatewayInterface
             'headers'         => [
                 'Accept' => 'application/json',
             ],
-            'body' => $params,
+            'form_params' => $params,
         ]);
 
         if (substr((string) $rawResponse->getStatusCode(), 0, 1) === '2') {


### PR DESCRIPTION
Changed the "body" request to "form_params". This is fixed that error:

Passing in the "body" request option as an array to send a POST request
has been deprecated. Please use the "form_params" request option to send
a application/x-www-form-urlencoded request, or a the "multipart"
request option to send a multipart/form-data request.